### PR TITLE
[bugfix] mcreate with error should fail for a reason

### DIFF
--- a/auth.feature
+++ b/auth.feature
@@ -20,7 +20,7 @@ Feature: User management
     And I log in as 'my-user-name':'my-user-pwd'
     And I update my user custom data with the pair <field-name>:<field-value>
     When I get my user info
-    Then the response '_source' field contains the pair <field-name>:<field-value>
+    Then the response 'content' field contains the pair <field-name>:<field-value>
     Examples:
       | field-name | field-value |
       | 'my_data' | 'mystringvalue' |

--- a/documents.feature
+++ b/documents.feature
@@ -133,6 +133,7 @@ Feature: Document management
     Given Kuzzle Server is running
     And there is an index 'test-index'
     And it has a collection 'mcreate-test-collection'
+    And the collection has a document with id 'mcreate-my-document-id'
     And the collection doesn't have a document with id 'mcreate-my-document-id'
     And the collection doesn't have a document with id 'mcreate-my-document-id2'
     When I create the documents ['mcreate-my-document-id', 'mcreate-my-document-id2']

--- a/documents.feature
+++ b/documents.feature
@@ -133,7 +133,6 @@ Feature: Document management
     Given Kuzzle Server is running
     And there is an index 'test-index'
     And it has a collection 'mcreate-test-collection'
-    And the collection has a document with id 'mcreate-my-document-id'
     And the collection doesn't have a document with id 'mcreate-my-document-id'
     And the collection doesn't have a document with id 'mcreate-my-document-id2'
     When I create the documents ['mcreate-my-document-id', 'mcreate-my-document-id2']
@@ -144,6 +143,7 @@ Feature: Document management
     Given Kuzzle Server is running
     And there is an index 'test-index'
     And it has a collection 'mcreate-test-collection'
+    And the collection has a document with id 'mcreate-my-document-id'
     When I create the documents ['mcreate-my-document-id', 'mcreate-my-document-id2']
     Then I must have 2 documents in the collection
     And I get a partial error


### PR DESCRIPTION
Fixes

1. the scenario "Create multiple documents with partial error" by actually creating an error case.

NB: the tests pass with the faulty version on both cpp & java sdks because no clean-up is performed between scenarios and the previous one creates the documents (which is not good).

2. fix the source field to get user info from